### PR TITLE
Use Http/2 by default in Kiota

### DIFF
--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -538,6 +538,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             {
                 Method = new HttpMethod(requestInfo.HttpMethod.ToString().ToUpperInvariant()),
                 RequestUri = requestUri,
+                Version=new Version(2,0)
             };
 
             if(requestInfo.RequestOptions.Any())


### PR DESCRIPTION
Fix issue https://github.com/microsoft/kiota-http-dotnet/issues/231